### PR TITLE
install latest material-ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/Lemoncode/simplechart#readme",
   "dependencies": {
+    "@material-ui/core": "^3.0.1",
     "@zeit/next-sass": "^0.2.0",
     "@zeit/next-typescript": "^1.1.0",
     "babel-polyfill": "^6.26.0",
@@ -32,7 +33,6 @@
     "d3-composite-projections": "^1.2.0",
     "express": "^4.16.3",
     "isomorphic-unfetch": "^2.1.1",
-    "material-ui": "^0.20.0",
     "next": "^6.1.1",
     "qs": "^6.5.2",
     "react": "^16.2.0",
@@ -47,7 +47,6 @@
     "@types/enzyme": "^3.1.9",
     "@types/geojson": "^7946.0.4",
     "@types/jest": "^22.2.0",
-    "@types/material-ui": "^0.20.7",
     "@types/next": "^6.1.4",
     "@types/node": "^9.4.6",
     "@types/react": "^16.0.38",


### PR DESCRIPTION
Right now we are not using material-ui for nothing.

Should we uninstall this lib?